### PR TITLE
Change marker date data type to String

### DIFF
--- a/Marker/markerModel.js
+++ b/Marker/markerModel.js
@@ -5,9 +5,8 @@ const mongoose = require('mongoose');
 const markerSchema = mongoose.Schema({
   incidentType: { type: String },
   time: { type: String },
-  date: { type: Date, default: Date.now },
+  date: { type: String },
   location: { type: Object, required: true }, // [long, lat]
-  // TODO: change default marker
   icon: {
     type: String,
     default:


### PR DESCRIPTION
The data type for the `date` field in the Marker model was `type: Date, default: Default.now.` This has been removed and the date is now saved as a string.